### PR TITLE
Cause strings that resemble timestemps to be quoted when they're encoded

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -298,6 +298,13 @@ func isBase60Float(s string) (result bool) {
 // is bogus. In practice parsers do not enforce the "\.[0-9_]*" suffix.
 var base60float = regexp.MustCompile(`^[-+]?[0-9][0-9_]*(?::[0-5]?[0-9])+(?:\.[0-9_]*)?$`)
 
+func isDate(s string) (result bool) {
+	return date.MatchString(s)
+}
+
+// From http://yaml.org/type/timestamp.html
+var date = regexp.MustCompile(`^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]|[0-9][0-9][0-9][0-9]-[0-9][0-9]?-[0-9][0-9]?([Tt]|[ \t]+)[0-9][0-9]?:[0-9][0-9]:[0-9][0-9](\.[0-9]*)?(([ \t]*)Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?$`)
+
 func (e *encoder) stringv(tag string, in reflect.Value) {
 	var style yaml_scalar_style_t
 	s := in.String()
@@ -319,7 +326,7 @@ func (e *encoder) stringv(tag string, in reflect.Value) {
 		// tag when encoded unquoted. If it doesn't,
 		// there's no need to quote it.
 		rtag, _ := resolve("", s)
-		canUsePlain = rtag == strTag && !isBase60Float(s)
+		canUsePlain = rtag == strTag && !isBase60Float(s) && !isDate(s)
 	}
 	// Note: it's possible for user code to emit invalid YAML
 	// if they explicitly specify a tag and a string containing


### PR DESCRIPTION
I think after this is merged, I'll have to update the CLI's go.mod and go.sum files to cause the change to be picked up -- go.mod incorporates the git sha being used. 

The situation with yaml parsers in the CLI is unfortunate..  The go-yaml package has different versions available, we started out using v1 but then I needed v3 to make "!Ref" etc. work.  And then we have vendored v1 (in this repo) to fix the YES/NO issue plus this timestamp issue.  It looks like v3 fixes the YES/NO issue but doesn't appear to fix the timestamp issue, so even if I converted all the CLI's uses to v3 we would still have to have a vendored version...

Someone else had made a similar complaint about the V1 yaml encoder and had submitted a similar fix -- I just made a small improvement to their fix.  So if we're encoding a string that looks like a date, we have to quote the date-like string.
